### PR TITLE
correctly generate version export in main library

### DIFF
--- a/lib/to.js
+++ b/lib/to.js
@@ -73,5 +73,5 @@ exports.stringify = function(doc) {
 
 /* Version of this lib
  */
-exports.version = handy.getVersion();
+exports.version = handy.getVersion(path.join(__dirname, 'package.json'));
 


### PR DESCRIPTION
since npm@3, node_modules directory might be flattened out. Since version is supposed to be the version of the "to" library, getVersion should explicitly provide the package.json of the project, instead of relying on handy to determine the correct one.

This fixes https://github.com/assemble/handlebars-helpers/issues/199
