### PR TITLE
specify explicit path for `getVersion`

### DIFF
--- a/lib/to.js
+++ b/lib/to.js
@@ -73,5 +73,5 @@ exports.stringify = function(doc) {
 
 /* Version of this lib
  */
-exports.version = handy.getVersion();
+exports.version = handy.getVersion(path.join(__dirname, '..'));
 


### PR DESCRIPTION
This fixes a bug when using NPM@3. Here it's quite common that both `handy` and `to` are installed into the project's top-level `node_modules` directory. As such `getVersion` would actually access the project's package.json and not that of handy.

There is another pull request for this but it has a bug itself, since it tries to pass the 'package.json' file to `getVersion()`, but the latter actually wants a module path.
